### PR TITLE
Add methods to plot CDDF and spectra from Solene catalog

### DIFF
--- a/CDDF_analysis/make_dr16q_plots.py
+++ b/CDDF_analysis/make_dr16q_plots.py
@@ -732,6 +732,7 @@ def do_Parks_dNdX(
     search_range_from_ours: bool = False,
     plot_gp: bool = True,
     subdir_gp: str = "CDDF_analysis/dr16q_full_int_lyb_occam_zqso7_1_30_delta_z_0_1/",
+    lnhi_min: float = 20.3,
 ):
     """
     Plot dNdX for Parks' CNN model in the DR16Q
@@ -759,6 +760,7 @@ def do_Parks_dNdX(
         solene_dlas=solene_dlas,
         voigt_fitter=voigt_fitter,
         our_sightlines=our_sightlines,
+        lnhi_min=lnhi_min,
     )
     np.savetxt(os.path.join(subdir, "dndx_all.txt"), (z_cent, dNdX))
 

--- a/CDDF_analysis/make_dr16q_plots.py
+++ b/CDDF_analysis/make_dr16q_plots.py
@@ -2,6 +2,7 @@
 Make plots for the Multi-DLA paper
 """
 import os
+import pathlib
 import numpy as np
 from scipy.stats import pearsonr
 from scipy.interpolate import interp1d
@@ -571,36 +572,55 @@ def plot_omega_dla(
 
 def do_Parks_CDDF(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
-    subdir: str = "CDDF_analysis/parks_cddf_dr16q/",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits", # "data/dr16q/distfiles/DLA_CAT_SDSS_DR16.fits"
+    subdir: str = "CDDF_analysis/parks_cddf_dr16q/", # CDDF_analysis/solene_cddf_dr16q
     p_thresh: float = 0.98,
     snr_thresh: float = -2.0,
+    solene_dlas: bool = False, # Solene only
+    voigt_fitter: bool = False, # Solene only
+    our_sightlines: bool = True, # Solene only
     lyb: bool = False,
+    min_1040: bool = False,
     search_range_from_ours: bool = False,
     plot_gp: bool = True,
     subdir_gp: str = "CDDF_analysis/dr16q_full_int_lyb_occam_zqso7_1_30_delta_z_0_1/",
 ):
     """
-    Plot the column density function of Parks (2018)
+    Plot the column density function of Parks (2018) or Solene (2021)
 
     Parameters:
     ----
-    dla_parks (str) : path to Parks' CNN model in the DR16Q
+    dla_cnn (str) : path to Parks' CNN model in the DR16Q
     """
+
+    pathlib.Path(subdir).mkdir(parents=True, exist_ok=True)
+
     dla_data.noterdaeme_12_data()
     (l_N, cddf) = qsos.plot_cddf_parks(
-        dla_parks,
+        dla_cnn,
         zmax=5,
         color="C4",
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         apply_p_dlas=False,
-        prior=False,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
         label="CNN",
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
-    np.savetxt(os.path.join(subdir, "cddf_parks_all.txt"), (l_N, cddf))
+
+    # set the specialized figure names, and double check the args
+    if solene_dlas:
+        assert "dict_solene" in dir(qsos)
+        figname = "solene"
+    else:
+        assert ~voigt_fitter
+        figname = "parks"
+
+    np.savetxt(os.path.join(subdir, "cddf_{}_all.txt".format(figname)), (l_N, cddf))
 
     # plot alongside with GP model
     if plot_gp:
@@ -617,12 +637,12 @@ def do_Parks_CDDF(
     plt.ylim(1e-28, 5e-21)
     plt.legend(loc=0)
     plt.tight_layout()
-    save_figure(os.path.join(subdir, "cddf_parks"))
+    save_figure(os.path.join(subdir, "cddf_{}".format(figname)))
     plt.clf()
 
     # Evolution with redshift
     (l_N, cddf) = qsos.plot_cddf_parks(
-        dla_parks,
+        dla_cnn,
         zmin=4,
         zmax=5,
         label="4-5",
@@ -630,13 +650,16 @@ def do_Parks_CDDF(
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         apply_p_dlas=False,
-        prior=False,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
-    np.savetxt(os.path.join(subdir, "cddf_parks_z45.txt"), (l_N, cddf))
+    np.savetxt(os.path.join(subdir, "cddf_{}_z45.txt".format(figname)), (l_N, cddf))
     (l_N, cddf) = qsos.plot_cddf_parks(
-        dla_parks,
+        dla_cnn,
         zmin=3,
         zmax=4,
         label="3-4",
@@ -644,13 +667,16 @@ def do_Parks_CDDF(
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         apply_p_dlas=False,
-        prior=False,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
-    np.savetxt(os.path.join(subdir, "cddf_parks_z34.txt"), (l_N, cddf))
+    np.savetxt(os.path.join(subdir, "cddf_{}_z34.txt".format(figname)), (l_N, cddf))
     (l_N, cddf) = qsos.plot_cddf_parks(
-        dla_parks,
+        dla_cnn,
         zmin=2.5,
         zmax=3,
         label="2.5-3",
@@ -658,13 +684,16 @@ def do_Parks_CDDF(
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         apply_p_dlas=False,
-        prior=False,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
-    np.savetxt(os.path.join(subdir, "cddf_parks_z253.txt"), (l_N, cddf))
+    np.savetxt(os.path.join(subdir, "cddf_{}_z253.txt".format(figname)), (l_N, cddf))
     (l_N, cddf) = qsos.plot_cddf_parks(
-        dla_parks,
+        dla_cnn,
         zmin=2,
         zmax=2.5,
         label="2-2.5",
@@ -672,27 +701,34 @@ def do_Parks_CDDF(
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         apply_p_dlas=False,
-        prior=False,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
-    np.savetxt(os.path.join(subdir, "cddf_parks_z225.txt"), (l_N, cddf))
+    np.savetxt(os.path.join(subdir, "cddf_{}_z225.txt".format(figname)), (l_N, cddf))
 
     plt.xlim(1e20, 1e23)
     plt.ylim(1e-28, 5e-21)
     plt.legend(loc=0)
     plt.tight_layout()
-    save_figure(os.path.join(subdir, "cddf_zz_parks"))
+    save_figure(os.path.join(subdir, "cddf_zz_{}".format(figname)))
     plt.clf()
 
 
 def do_Parks_dNdX(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
-    subdir: str = "CDDF_analysis/parks_cddf_dr16q/",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits", # "data/dr16q/distfiles/DLA_CAT_SDSS_DR16.fits"
+    subdir: str = "CDDF_analysis/parks_cddf_dr16q/", # CDDF_analysis/solene_cddf_dr16q
     p_thresh: float = 0.98,
     snr_thresh: float = -2.0,
+    solene_dlas: bool = False, # Solene only
+    voigt_fitter: bool = False, # Solene only
+    our_sightlines: bool = True, # Solene only
     lyb: bool = False,
+    min_1040: bool = False,
     search_range_from_ours: bool = False,
     plot_gp: bool = True,
     subdir_gp: str = "CDDF_analysis/dr16q_full_int_lyb_occam_zqso7_1_30_delta_z_0_1/",
@@ -702,23 +738,37 @@ def do_Parks_dNdX(
 
     Parameters:
     ----
-    dla_parks (str) : path to Parks' CNN model in the DR16Q
+    dla_cnn (str) : path to Parks' CNN model in the DR16Q
     """
+
+    pathlib.Path(subdir).mkdir(parents=True, exist_ok=True)
+
     dla_data.dndx_not()
     dla_data.dndx_pro()
     z_cent, dNdX = qsos.plot_line_density_park(
-        dla_parks,
+        dla_cnn,
         zmax=5,
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         apply_p_dlas=False,
-        prior=False,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
         color="C4",
         label="CNN",
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
     np.savetxt(os.path.join(subdir, "dndx_all.txt"), (z_cent, dNdX))
+
+    # set the specialized figure names, and double check the args
+    if solene_dlas:
+        assert "dict_solene" in dir(qsos)
+        figname = "solene"
+    else:
+        assert ~voigt_fitter
+        figname = "parks"
 
     # (z_cent, dNdX, dndx68[:,0],dndx68[:,1], dndx95[:,0],dndx95[:,1]) in (6, N) shape
     if plot_gp:
@@ -741,19 +791,23 @@ def do_Parks_dNdX(
     plt.legend(loc=0)
     plt.ylim(0, 0.16)
     plt.tight_layout()
-    save_figure(os.path.join(subdir, "dndx_parks"))
+    save_figure(os.path.join(subdir, "dndx_{}".format(figname)))
     plt.clf()
 
 
 def do_Parks_OmegaDLA(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
-    subdir: str = "CDDF_analysis/parks_cddf_dr16q/",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits", # "data/dr16q/distfiles/DLA_CAT_SDSS_DR16.fits"
+    subdir: str = "CDDF_analysis/parks_cddf_dr16q/", # CDDF_analysis/solene_cddf_dr16q
     zmin: float = 2.0,
     zmax: float = 4.0,
     p_thresh: float = 0.98,
     snr_thresh: float = -2.0,
+    solene_dlas: bool = False, # Solene only
+    voigt_fitter: bool = False, # Solene only
+    our_sightlines: bool = True, # Solene only
     lyb: bool = False,
+    min_1040: bool = False,
     search_range_from_ours: bool = False,
     plot_gp: bool = True,
     subdir_gp: str = "CDDF_analysis/dr16q_full_int_lyb_occam_zqso7_1_30_delta_z_0_1/",
@@ -761,24 +815,39 @@ def do_Parks_OmegaDLA(
     """
     Plot OmegaDLA for Parks's CNN model in DR16Q
     """
+
+    pathlib.Path(subdir).mkdir(parents=True, exist_ok=True)
+
     # Omega_DLA
     dla_data.omegahi_not()
     dla_data.omegahi_pro()
     dla_data.crighton_omega()
 
     (z_cent, omega_dla) = qsos.plot_omega_dla_parks(
-        dla_parks,
+        dla_cnn,
         zmin=zmin,
         zmax=zmax,
         p_thresh=p_thresh,
         snr_thresh=snr_thresh,
         lyb=lyb,
+        min_1040=min_1040,
         search_range_from_ours=search_range_from_ours,
         color="C4",
         label="CNN",
+        solene_dlas=solene_dlas,
+        voigt_fitter=voigt_fitter,
+        our_sightlines=our_sightlines,
     )
 
     np.savetxt(os.path.join(subdir, "omega_dla_all.txt"), (z_cent, omega_dla))
+
+    # set the specialized figure names, and double check the args
+    if solene_dlas:
+        assert "dict_solene" in dir(qsos)
+        figname = "solene"
+    else:
+        assert ~voigt_fitter
+        figname = "parks"
 
     # (z_cent, omega_dla, omega_dla_68[:,0],omega_dla_68[:,1], omega_dla_95[:,0], omega_dla_95[:,1]) in (6, N) shape
     if plot_gp:
@@ -802,13 +871,13 @@ def do_Parks_OmegaDLA(
     plt.xlim(2, 5)
     plt.ylim(0, 2.5)
     plt.tight_layout()
-    save_figure(os.path.join(subdir, "omega_parks"))
+    save_figure(os.path.join(subdir, "omega_{}".format(figname)))
     plt.clf()
 
 
 def do_Parks_snr_check(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits",
     subdir: str = "CDDF_analysis/parks_cddf_dr16q/",
     p_thresh: float = 0.98,
     lyb: bool = False,
@@ -823,14 +892,13 @@ def do_Parks_snr_check(
     dla_data.noterdaeme_12_data()
     for i, snr_thresh in enumerate(snrs_list):
         (l_N, cddf) = qsos.plot_cddf_parks(
-            dla_parks,
+            dla_cnn,
             zmax=5,
             p_thresh=p_thresh,
             color=cmap((i + 1) / len(snrs_list)),
             snr_thresh=snr_thresh,
             label="Parks SNR > {:d}".format(snr_thresh),
             apply_p_dlas=False,
-            prior=False,
             lyb=lyb,
             search_range_from_ours=search_range_from_ours,
         )
@@ -846,14 +914,13 @@ def do_Parks_snr_check(
     dla_data.dndx_pro()
     for i, snr_thresh in enumerate(snrs_list):
         z_cent, dNdX = qsos.plot_line_density_park(
-            dla_parks,
+            dla_cnn,
             zmax=5,
             p_thresh=p_thresh,
             color=cmap((i + 1) / len(snrs_list)),
             snr_thresh=snr_thresh,
             label="Parks SNR > {:d}".format(snr_thresh),
             apply_p_dlas=False,
-            prior=False,
             lyb=lyb,
             search_range_from_ours=search_range_from_ours,
         )
@@ -866,7 +933,7 @@ def do_Parks_snr_check(
 
 def do_confusion_parks(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits",
     snr: float = -1.0,
     dla_confidence: float = 0.98,
     p_thresh: float = 0.98,
@@ -877,7 +944,7 @@ def do_confusion_parks(
     """
     if "dla_catalog_parks" not in dir(qsos):
         qsos.load_dla_parks(
-            dla_parks, p_thresh=dla_confidence, multi_dla=False, num_dla=1
+            dla_cnn, p_thresh=dla_confidence, multi_dla=False, num_dla=1
         )
 
     confusion_matrix, _ = qsos.make_multi_confusion(
@@ -910,7 +977,7 @@ def do_confusion_parks(
 
 def do_MAP_parks_comparison(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits",
     dla_confidence: float = 0.98,
     num_dlas: int = 1,
     num_bins: int = 100,
@@ -920,7 +987,7 @@ def do_MAP_parks_comparison(
     """
     if "dla_catalog_parks" not in dir(qsos):
         qsos.load_dla_parks(
-            dla_parks, p_thresh=dla_confidence, multi_dla=False, num_dla=1
+            dla_cnn, p_thresh=dla_confidence, multi_dla=False, num_dla=1
         )
 
     Delta_z_dlas, Delta_log_nhis, z_dlas_parks = qsos.make_MAP_parks_comparison(
@@ -1024,7 +1091,7 @@ def do_MAP_parks_comparison(
 
 def do_MAP_hist2d_parks(
     qsos: QSOLoaderDR16Q,
-    dla_parks: str = "data/dr16q/distfiles/DR16Q_v4.fits",
+    dla_cnn: str = "data/dr16q/distfiles/DR16Q_v4.fits",
     dla_confidence: float = 0.98,
     num_dlas: int = 1,
 ):
@@ -1033,7 +1100,7 @@ def do_MAP_hist2d_parks(
     """
     if "dla_catalog_parks" not in dir(qsos):
         qsos.load_dla_parks(
-            dla_parks, p_thresh=dla_confidence, multi_dla=False, num_dla=1
+            dla_cnn, p_thresh=dla_confidence, multi_dla=False, num_dla=1
         )
 
     (

--- a/CDDF_analysis/make_dr16q_plots.py
+++ b/CDDF_analysis/make_dr16q_plots.py
@@ -1236,3 +1236,43 @@ def do_plot_this_mu_with_labels(
     plt.tight_layout()
     save_figure("this_mu_{}".format(qsos_dr16q.thing_ids[nspec]))
     plt.show()
+
+def plot_this_mu_overlapping_dlas(qsos: QSOLoaderDR16Q, Parks: bool = True, Solene: bool = True):
+    """
+    Plot the comparison of Parks, Solene, ours on spectra with solid DLA detections
+    but overlapping/nearby DLAs.
+    """
+    selected_thing_ids = [
+        147946665,
+        177872172,
+        194921144,
+        209755715,
+        225460412,
+        229232104,
+        236392107,
+        248088771,
+        268065713,
+        269549832,
+        296660604,
+        307451922,
+        332071702,
+        349105103,
+        371695814,
+        37208460,
+        416180602,
+        473203069,
+        487498804,
+        488562798,
+        501293410,
+        540640951,
+        54806980,
+        60605850,
+    ]
+
+    all_specs = np.where(np.isin(qsos.thing_ids, selected_thing_ids))[0]
+
+    for nspec in all_specs:
+        qsos.plot_this_mu(nspec, Parks=Parks, Solene=Solene, voigt_fitter=False, dla_solene="data/dr16q/distfiles/DLA_CAT_SDSS_DR16.fits")
+        plt.ylim(-1, 5)
+        save_figure("plot_specs/CNN_overlaps/this_mu_{}".format(qsos.thing_ids[nspec]))
+        plt.show()

--- a/CDDF_analysis/qso_loader.py
+++ b/CDDF_analysis/qso_loader.py
@@ -917,6 +917,9 @@ class QSOLoader(object):
 
     @staticmethod
     def make_unique_id(plates, mjds, fiber_ids):
+        plates = np.int64(plates)
+        mjds = np.int64(mjds)
+        fiber_ids = np.int64(fiber_ids)
         return plates * 10 ** 9 + mjds * 10 ** 4 + fiber_ids
 
     def make_multi_unique_id(self, num_dla, plates, mjds, fiber_ids):

--- a/CDDF_analysis/qso_loader.py
+++ b/CDDF_analysis/qso_loader.py
@@ -1573,7 +1573,6 @@ class QSOLoader(object):
 
             snrs[i] = self.snrs[real_index]
             log_priors_dla[i] = self.log_priors_dla[real_index]
-
         # re-calculate dla_confidence based on prior of DLAs given z_qsos
         if prior:
             p_dlas = p_dlas * np.exp(log_priors_dla)
@@ -1768,6 +1767,12 @@ class QSOLoader(object):
         else:
             tot_f_N, NHI_table = np.histogram(10 ** log_nhis, 10 ** lnhis)
 
+        # Remove duplicate sightlines
+        # TODO: This strongly disagrees with N12. Comment out for now.
+        _, real_index = np.unique(unique_ids, return_index=True)
+        # dX = self.path_length(min_z_dlas[real_index], max_z_dlas[real_index], z_min, z_max)
+        # 
+        # Only counts maximum 1 DLA per spec. Multiple DLAs count multiply
         dX = self.path_length(min_z_dlas, max_z_dlas, z_min, z_max)
         dN = np.array(
             [
@@ -1870,6 +1875,17 @@ class QSOLoader(object):
         else:
             ndlas, _ = np.histogram(z_dlas, z_bins)
 
+        # Remove duplicate sightlines
+        # TODO: This strongly disagrees with N12. Comment out for now.
+        # _, real_index = np.unique(unique_ids, return_index=True)
+        # dX = np.array(
+        #     [
+        #         self.path_length(min_z_dlas[real_index], max_z_dlas[real_index], z_m, z_x)
+        #         for (z_m, z_x) in zip(z_bins[:-1], z_bins[1:])
+        #     ]
+        # )
+        # 
+        # Only counts maximum 1 DLA per spec. Multiple DLAs count multiply
         # calc dX for z_bins
         dX = np.array(
             [
@@ -1964,6 +1980,17 @@ class QSOLoader(object):
         # proton mass in g
         protonmass = 1.67262178e-24
 
+        # Remove duplicate sightlines
+        # TODO: This strongly disagrees with N12. Comment out for now.
+        # _, real_index = np.unique(unique_ids, return_index=True)
+        # dX = np.array(
+        #     [
+        #         self.path_length(min_z_dlas[real_index], max_z_dlas[real_index], z_m, z_x)
+        #         for (z_m, z_x) in zip(z_bins[:-1], z_bins[1:])
+        #     ]
+        # )
+        # 
+        # Only counts maximum 1 DLA per spec. Multiple DLAs count multiply
         # calc dX for z_bins
         dX = np.array(
             [

--- a/CDDF_analysis/qso_loader_dr16q.py
+++ b/CDDF_analysis/qso_loader_dr16q.py
@@ -527,7 +527,7 @@ class QSOLoaderDR16Q(QSOLoader):
         ind_solene_dla = np.isin(unique_ids_dr16q, unique_ids_solene_dlas)
         # 2) DR16 sightlines with filtering condition set by Solene
         ind_solene_los = solene_eBOSS_cuts(
-            self.hdu[1].data["Z_LYAWG"],
+            self.hdu[1].data["Z_PCA"], # self.hdu[1].data["Z_LYAWG"], # TODO: why some Solene's DLAs don't have Z_LYAWG?
             self.hdu[1].data["ZWARNING"],
             self.hdu[1].data["BAL_PROB"],
         )
@@ -537,11 +537,12 @@ class QSOLoaderDR16Q(QSOLoader):
             for z in self.hdu[1].data["ZWARNING"][ind_solene_los]
         ])
         # DLA set should be a subset of LOS set
-        import pdb
-        pdb.set_trace()
-        assert np.sum(~ind_solene_los & ind_solene_dla) == 0
+        # import pdb
+        # pdb.set_trace()
+        # assert np.sum(~ind_solene_los & ind_solene_dla) == 0 # TODO: it never passes due to many -1 in ZWARNING
         # 3) GP's line of sights
         if our_sightlines:
+            print("[Info] Load only our sightlines from Solene's.")
             # awkward way to apply condition to test_ind 
             ind_gp_los = self.test_ind
             real_index = np.where(self.test_ind)[0]
@@ -576,7 +577,7 @@ class QSOLoaderDR16Q(QSOLoader):
         plates = np.append(plates, self.hdu[1].data["PLATE"][ind_add_los])
         mjds = np.append(mjds, self.hdu[1].data["MJD"][ind_add_los])
         fiber_ids = np.append(fiber_ids, self.hdu[1].data["FIBERID"][ind_add_los])
-        z_qsos = np.append(z_qsos, self.hdu[1].data["Z_LYAWG"][ind_add_los])
+        z_qsos = np.append(z_qsos, self.hdu[1].data["Z_PCA"][ind_add_los]) # TODO: why some Solene's DLAs don't have Z_LYAWG?
         thing_ids = np.append(thing_ids, self.hdu[1].data["THING_ID"][ind_add_los])
         # append NaNs for LOS (non-detections)
         dla_confidences = np.append(dla_confidences, np.full((np.sum(ind_add_los), ), fill_value=np.nan))
@@ -674,9 +675,6 @@ class QSOLoaderDR16Q(QSOLoader):
         for i, thing_id in enumerate(thing_ids):
             real_index = np.where(self.thing_ids == thing_id)[0][0]
             all_snrs[i] = self.snrs[real_index]
-
-        import pdb
-        pdb.set_trace()
 
         # the searching range for the DLAs.
         if lyb:

--- a/CDDF_analysis/qso_loader_dr16q.py
+++ b/CDDF_analysis/qso_loader_dr16q.py
@@ -2,9 +2,12 @@
 QSOLoader for DR16Q GP catalogue
 """
 
+from json import dump
+from types import BuiltinFunctionType
 from typing import Dict, List, Tuple
 
 from collections import namedtuple, Counter
+from astropy.io.fits import hdu
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -16,6 +19,7 @@ from .set_parameters import *
 from .qso_loader import QSOLoader, GPLoader, conditional_mvnpdf_low_rank, make_fig
 from .voigt import Voigt_absorption
 from .effective_optical_depth import effective_optical_depth
+from .solene_dlas import solene_eBOSS_cuts
 
 class QSOLoaderDR16Q(QSOLoader):
     def __init__(
@@ -436,13 +440,150 @@ class QSOLoaderDR16Q(QSOLoader):
 
         return dict_parks
 
+    def prediction_solene2dict(self, dist_file: str, our_sightlines: bool = False, voigt_fitter: bool = False) -> Dict:
+        """
+        Get Solene's CNN predictions on DR16Q catalogue
+
+        TODO:
+        Need to load both NHI_CNN and NHI_FIT in order to plot CDDFs using different NHIs.
+        Need to get thingIDs from DR16Q and filtering using Solene's conditions (Given as follows).
+        This is due to Solene's catalogue only includes positive DLA detections, not negative detections.
+        But to calculate dX (total path length), sightlines with negative detections are required.
+
+        DLA_CAT_SDSS_DR16.fits (Chabanier+21)
+        *************************************************************************************
+        Results of the DLA search using the CNN from Parks+18 on the 263,201 QSO spectra from
+        the SDSS-IV quasar catalog from DR16 (Lyke+20) with 2 <= Z_QSO <= 6 and Z_WARNING !=
+        SKY, LITTLE_COVERAGE, UNPLUGGED, BAD_TARGET or NODATA.
+
+        The fits file contains an array of the 117,458 detected absorbers in sightlines with BAL_PROB =
+        0 and absorbing redshift Z_CNN >= 2.
+
+        Some additional information
+        Z_QSO: using Z_LYAWG
+        NHI_FIT: The logarithm of the absorber column density as found by the Voigt-profile fitter for
+            absorbers in the rest-frame range $1,040 \angstrom \leq \lambda_{\rm RF} \leq 1,216
+            \angstrom$ and $\log \nhi < 22$. This parameter is set to -1 for absorbers that do not
+            meet the criteria
+        Z_CNN: the absorber redshift as found by the CNN
+        NHI_CNN: the logarithm of the absorber column density as found by the CNN
+        CONF_CNN: confidence parameter, between 0 and 1. Absorbers with confidence > 0.5 are
+            considered as confident absorbers.
+        """
+        hdu_solene = fits.open(dist_file)
+
+        # extract DLA information: Solene's catalogue allows duplicate THING_IDs for
+        # multiple DLAs at the same sightline. We will need to append non-DLA sightline
+        # from DR16Q afterward.
+        ras = hdu_solene[1].data["RA"]
+        decs = hdu_solene[1].data["DEC"]
+        plates = hdu_solene[1].data["PLATE"]
+        mjds = hdu_solene[1].data["MJD"]
+        fiber_ids = hdu_solene[1].data["FIBERID"]
+        z_qsos = hdu_solene[1].data["Z_QSO"]
+        thing_ids = hdu_solene[1].data["THING_ID"]
+
+        dla_confidences = hdu_solene[1].data["CONF_CNN"]
+        z_dlas = hdu_solene[1].data["Z_CNN"]
+        log_nhis = hdu_solene[1].data["NHI_CNN"]
+        log_nhis_fitter = hdu_solene[1].data["NHI_FIT"]
+
+        assert np.all(dla_confidences >= 0)
+        assert np.all(dla_confidences <= 1)
+        assert np.all(log_nhis >= 19.5)
+        assert np.all(z_dlas >= 2)
+
+        # TODO: Check again here if results are not sensible. Not sure if -1 DLAs are
+        #   considered to be null detections.
+        #   Use Voigt fitter as NHI: only a subset of DLAs has applied Voigt fit
+        #   DLAs do not fit the fitting criteria as set with -1
+        if voigt_fitter:
+            ind_no_fitter = (log_nhis_fitter == -1)
+
+            ras = ras[~ind_no_fitter]
+            decs = decs[~ind_no_fitter]
+            plates = plates[~ind_no_fitter]
+            mjds = mjds[~ind_no_fitter]
+            fiber_ids = fiber_ids[~ind_no_fitter]
+            z_qsos = z_qsos[~ind_no_fitter]
+
+            dla_confidences = dla_confidences[~ind_no_fitter]
+            z_dlas = z_dlas[~ind_no_fitter]
+            # log_nhis = log_nhis[~ind_no_fitter] # keep the CNN one for future comparison
+            log_nhis_fitter = log_nhis_fitter[~ind_no_fitter]
+
+            log_nhis = log_nhis_fitter
+
+            assert np.all( log_nhis_fitter >= 19.3 ) # strangely the min of fitter is ~19.3
+
+        # only append the thingIDs that are not in Solene's DLAs
+        # 1) search Solene's DLA thingIDs in DR16Q
+        # ind_solene_dla = np.isin(self.hdu[1].data["THING_ID"], thing_ids)
+        # not using thingID because -1 duplicated
+        unique_ids_dr16q = self.make_unique_id(self.hdu[1].data["PLATE"], self.hdu[1].data["MJD"], self.hdu[1].data["FIBERID"])
+        unique_ids_solene_dlas = self.make_unique_id(plates, mjds, fiber_ids)
+        ind_solene_dla = np.isin(unique_ids_dr16q, unique_ids_solene_dlas)
+        # 2) DR16 sightlines with filtering condition set by Solene
+        ind_solene_los = solene_eBOSS_cuts(
+            self.hdu[1].data["Z_LYAWG"],
+            self.hdu[1].data["ZWARNING"],
+            self.hdu[1].data["BAL_PROB"],
+        )
+        # DLA set should be a subset of LOS set
+        assert np.sum(~ind_solene_los & ind_solene_dla) == 0
+        # 3) GP's line of sights
+        if our_sightlines:
+            ind_gp_los = self.test_ind
+            # only take the intersection of GP LOS and Solene LOS
+            ind_solene_los = ind_solene_los & ind_gp_los
+            # DLA sightlines should be a subset of solene LOS
+            ind_solene_dla = ind_solene_dla & ind_gp_los
+        # 4) add (non-DLA detection) sightlines to Solene's catalog
+        #    because the catalog did not have null detections.
+        ind_add_los = ind_solene_los & (~ind_solene_dla)
+
+        ras = np.append(ras, self.hdu[1].data["RA"][ind_add_los])
+        decs = np.append(decs, self.hdu[1].data["DEC"][ind_add_los])
+        plates = np.append(plates, self.hdu[1].data["PLATE"][ind_add_los])
+        mjds = np.append(mjds, self.hdu[1].data["MJD"][ind_add_los])
+        fiber_ids = np.append(fiber_ids, self.hdu[1].data["FIBERID"][ind_add_los])
+        z_qsos = np.append(z_qsos, self.hdu[1].data["Z_LYAWG"][ind_add_los])
+        thing_ids = np.append(thing_ids, self.hdu[1].data["THING_ID"][ind_add_los])
+        # append NaNs for LOS (non-detections)
+        dla_confidences = np.append(dla_confidences, np.full((np.sum(ind_add_los), ), fill_value=np.nan))
+        z_dlas = np.append(z_dlas, np.full((np.sum(ind_add_los), ), fill_value=np.nan))
+        log_nhis = np.append(log_nhis, np.full((np.sum(ind_add_los), ), fill_value=np.nan))
+        log_nhis_fitter = np.append(log_nhis_fitter, np.full((np.sum(ind_add_los), ), fill_value=np.nan))
+
+        assert np.all(z_qsos >= 2)
+
+
+        dict_solene = {
+            "thing_ids": thing_ids.astype(np.int),
+            "ras": ras,
+            "decs": decs,
+            "plates": plates.astype(np.int),
+            "mjds": mjds.astype(np.int),
+            "fiber_ids": fiber_ids.astype(np.int),
+            "z_qso": z_qsos,
+            "dla_confidences": dla_confidences,
+            "z_dlas": z_dlas,
+            "log_nhis": log_nhis,
+            "log_nhis_fitter": log_nhis_fitter,
+        }
+
+        return dict_solene
+
+
     def _get_parks_estimations(
         self,
-        dla_parks: str = "DR16Q_v4.fits",
+        dla_parks: str = "DR16Q_v4.fits", # DLA_CAT_SDSS_DR16.fits (Solene's catalog)
         p_thresh: float = 0.97,
         lyb: bool = False,
         prior: bool = False,
         search_range_from_ours: bool = False,
+        solene_dlas: bool = False,
+        voigt_fitter: bool = False,
     ) -> Tuple[
         np.ndarray,
         np.ndarray,
@@ -454,45 +595,45 @@ class QSOLoaderDR16Q(QSOLoader):
         np.ndarray,
     ]:
         """
-        Get z_dlas and log_nhis from Parks' (2018) estimations
+        Get z_dlas and log_nhis from Parks' (2018) or Solene's (2021) estimations
         """
         # make sure we are reading the DR16Q file
-        assert dla_parks in self.dist_file
+        # assert dla_parks in self.dist_file
 
-        if "dict_parks" not in dir(self):
-            self.dict_parks = self.prediction_parks2dict(
-                self.dist_file, selected_thing_ids=self.thing_ids
-            )
+        # voigt fitter only works for Solene's catalog
+        # also, the search range is 1040 ~ 1216
+        if voigt_fitter:
+            assert solene_dlas
+            assert (search_range_from_ours | lyb)
 
-        if "p_thresh" in self.dict_parks.keys():
-            if self.dict_parks["p_thresh"] == p_thresh:
-                thing_ids = self.dict_parks["cddf_thing_ids"]
-                log_nhis = self.dict_parks["cddf_log_nhis"]
-                z_dlas = self.dict_parks["cddf_z_dlas"]
-                min_z_dlas = self.dict_parks["min_z_dlas"]
-                max_z_dlas = self.dict_parks["max_z_dlas"]
-                snrs = self.dict_parks["snrs"]
-                all_snrs = self.dict_parks["all_snrs"]
-                p_dlas = self.dict_parks["cddf_p_dlas"]
-                p_thresh = self.dict_parks["p_thresh"]
-
-                return (
-                    thing_ids,
-                    log_nhis,
-                    z_dlas,
-                    min_z_dlas,
-                    max_z_dlas,
-                    snrs,
-                    all_snrs,
-                    p_dlas,
+        # avoid running it twice
+        if solene_dlas:
+            if "dict_solene" not in dir(self):
+                self.dict_solene = self.prediction_solene2dict(
+                    dla_parks, our_sightlines=True, voigt_fitter=voigt_fitter,
                 )
 
-        dict_parks = self.dict_parks
+            cnn_catalog = self.dict_solene
+
+            # assume log_nhis is overwritten by NHI_FIT
+            if voigt_fitter:
+                import pdb
+                pdb.set_trace()
+                ind = np.isnan(cnn_catalog["log_nhis"])
+                assert np.all(cnn_catalog["log_nhis"][~ind] == cnn_catalog["log_nhis_fitter"][~ind])
+
+        else:
+            if "dict_parks" not in dir(self):
+                self.dict_parks = self.prediction_parks2dict(
+                    dla_parks, selected_thing_ids=self.thing_ids
+                )
+
+            cnn_catalog = self.dict_parks
 
         # use thing_ids as an identifier
         # use zPCA as zQSOs, as said in DR16Q paper
-        thing_ids = dict_parks["thing_ids"]
-        z_qsos = dict_parks["z_qso"]
+        thing_ids = cnn_catalog["thing_ids"]
+        z_qsos = cnn_catalog["z_qso"]
 
         # fixed range of the sightline ranging from 911A-1215A in rest-frame
         # we should include all sightlines in the dataset
@@ -531,15 +672,15 @@ class QSOLoaderDR16Q(QSOLoader):
         # get DLA properties
         # note: the following indices are DLA-only
         dla_inds = (
-            dict_parks["dla_confidences"] > 0.005
+            cnn_catalog["dla_confidences"] > 0.005
         )  # use p_thresh=0.005 to filter out non-DLA spectra and
         # speed up the computation
 
         thing_ids = thing_ids[dla_inds]
-        log_nhis = dict_parks["log_nhis"][dla_inds]
-        z_dlas = dict_parks["z_dlas"][dla_inds]
-        z_qsos = dict_parks["z_qso"][dla_inds]
-        p_dlas = dict_parks["dla_confidences"][dla_inds]
+        log_nhis = cnn_catalog["log_nhis"][dla_inds]
+        z_dlas = cnn_catalog["z_dlas"][dla_inds]
+        z_qsos = cnn_catalog["z_qso"][dla_inds]
+        p_dlas = cnn_catalog["dla_confidences"][dla_inds]
 
         # for loop to get snrs from sbird's snrs file
         # Note arrays here are for DLA only

--- a/CDDF_analysis/solene_dlas.py
+++ b/CDDF_analysis/solene_dlas.py
@@ -45,7 +45,7 @@ def solene_eBOSS_cuts(z_qsos: int, zwarning: int, bal_prob: float) -> np.ndarray
         for b in solene_filter:
             fiter_yes = bitget_string(zw, b)
             if fiter_yes:
-                ind_z[i] = fiter_yes
+                ind_z[i] = False
                 break
 
     # 3) BAL prob

--- a/CDDF_analysis/solene_dlas.py
+++ b/CDDF_analysis/solene_dlas.py
@@ -1,0 +1,67 @@
+"""
+Functions for Solene's DLA catalog, from
+    The Completed SDSS-IV extended Baryon Oscillation
+    Spectroscopic Survey: The Damped Lyman-α systems Catalog
+    https://arxiv.org/abs/2107.09612
+
+Solene's catalogue:
+https://drive.google.com/drive/folders/1UaFHVwSNPpqkxTbcbR8mVRJ5BUR9KHzA
+"""
+
+import numpy as np
+
+from astropy.io import fits
+
+def solene_eBOSS_cuts(z_qsos: int, zwarning: int, bal_prob: float) -> np.ndarray:
+    """
+    DLA_CAT_SDSS_DR16.fits (Chabanier+21)
+    *************************************************************************************
+    Results of the DLA search using the CNN from Parks+18 on the 263,201 QSO spectra from
+    the SDSS-IV quasar catalog from DR16 (Lyke+20) with
+
+    (1) 2 <= Z_QSO <= 6
+
+    (2) Z_WARNING != 
+        SKY (0),
+        LITTLE_COVERAGE (1),
+        UNPLUGGED (7),
+        BAD_TARGET (8) or
+        NODATA (9).
+
+    (3) BAL_PROB = 0
+    """
+    # 1) Z_QSO
+    ind = (2 <= z_qsos) & (z_qsos <= 6)
+
+    # converting decimal ZWARNING to binary
+    zwarning_b = [format(z, "b") for z in zwarning]
+
+    # 2) ZWARNING: filtering based on Solene's condition
+    solene_filter = [0, 1, 7, 8, 9]
+
+    ind_z = np.ones(z_qsos.shape, dtype=np.bool_)
+
+    for i,zw in enumerate(zwarning_b):
+        for b in solene_filter:
+            fiter_yes = bitget_string(zw, b)
+            if fiter_yes:
+                ind_z[i] = fiter_yes
+                break
+
+    # 3) BAL prob
+    ind_bal = (bal_prob == 0)
+
+    ind = ind & ind_z & ind_bal
+
+    return ind
+
+def bitget_string(z: str, bit: int):
+    """
+    get the bit value at position bit:int, assume it's binary.
+    """
+    if bit >= len(z):
+        return False
+
+    bit_str = z[::-1][bit]
+
+    return bool(int(bit_str))


### PR DESCRIPTION
Solene's paper: https://arxiv.org/abs/2107.09612, [data drive]( https://drive.google.com/drive/folders/1UaFHVwSNPpqkxTbcbR8mVRJ5BUR9KHzA)

It's has NHI_CNN, NHI_FIT for column density estimations. NHI_CNN is from the CNN outputs; NHI_FIT one is from a Voigt fitter.

It does not have a list of quasar sightlines; it only has a list of sightlines has DLAs. I computed the quasar sightlines based on the selection criteria posted in the README of the catalog.